### PR TITLE
Consolidate iterative optimizers in PlanOptimizers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -464,10 +464,11 @@ public class PlanOptimizers
                                         new PreAggregateCaseAggregations(plannerContext),
                                         new RemoveRedundantDistinctAggregation()))
                                 .build()),
-                // MergeUnion and related projection pruning rules must run before limit pushdown rules, otherwise
-                // an intermediate limit node will prevent unions from being merged later on
+                // Union flattening must already be at fixpoint from InitialPlanCleanup before any
+                // limit-pushdown rules fire here, otherwise PushLimitThroughUnion would insert
+                // limits between nested unions and block MergeUnion.
                 new IterativeOptimizer(
-                        "MergeUnionsBeforeLimitPushdown",
+                        "Phase1",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
@@ -476,11 +477,11 @@ public class PlanOptimizers
                                 .addAll(projectionPushdownRules)
                                 .addAll(columnPruningRules)
                                 .addAll(limitPushdownRules)
+                                .addAll(simplifyOptimizerRules)
+                                .add(new ImplementOffset())
                                 .addAll(ImmutableSet.of(
-                                        new MergeUnion(),
                                         new RemoveEmptyUnionBranches(),
                                         new MergeFilters(),
-                                        new RemoveTrivialFilters(),
                                         new MergeLimits(),
                                         new MergeLimitWithSort(),
                                         new MergeLimitOverProjectWithSort(),
@@ -488,15 +489,6 @@ public class PlanOptimizers
                                         new InlineProjections(),
                                         new RemoveRedundantIdentityProjections()))
                                 .build()),
-                new IterativeOptimizer(
-                        "ImplementOffsets",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new ImplementOffset())),
-                simplifyOptimizer
-                        .withName("SimplifyExpressionsBeforeUnalias"),
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
                         "MergeSetOperations",

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -665,6 +665,8 @@ public class PlanOptimizers
                 .add(new PushLimitIntoTableScan(metadata))
                 .add(new PushPredicateIntoTableScan(plannerContext, false))
                 .add(new PushSampleIntoTableScan(metadata))
+                // Disjoint with PushSampleIntoTableScan (matches BERNOULLI, while PushSampleIntoTableScan matches SYSTEM).
+                .add(new ImplementBernoulliSampleAsFilter(metadata))
                 .add(new PushAggregationIntoTableScan(plannerContext))
                 .add(new PushDistinctLimitIntoTableScan(plannerContext))
                 .add(new PushTopNIntoTableScan(metadata))
@@ -696,17 +698,6 @@ public class PlanOptimizers
                         .build());
 
         builder.add(
-                new IterativeOptimizer(
-                        "ImplementBernoulliSample",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        // Temporary hack: separate optimizer step to avoid the sample node being replaced by filter before pushing
-                        // it to table scan node
-                        ImmutableSet.of(new ImplementBernoulliSampleAsFilter(metadata))),
-                columnPruningOptimizer
-                        .withName("PruneOutputsAfterSamplePushdown"),
                 new IterativeOptimizer(
                         "OptimizeDistinctAggregations",
                         plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -537,24 +537,18 @@ public class PlanOptimizers
                                 new ImplementIntersectAll(metadata),
                                 new ImplementExceptAll(metadata))),
                 new LimitPushDown(), // Run the LimitPushDown after flattening set operators to make it easier to do the set flattening
-                columnPruningOptimizer
-                        .withName("PruneOutputsAfterSetOperationRewrite"),
-                inlineProjections
-                        .withName("InlineProjectionsAfterSetRewrite"),
                 new IterativeOptimizer(
-                        "PruneAfterSetFlattening",
+                        "Phase2",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
                         costCalculator,
-                        columnPruningRules),
-                new IterativeOptimizer(
-                        "RewriteExistsApply",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new TransformExistsApplyToCorrelatedJoin(plannerContext))),
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(columnPruningRules)
+                                .add(new InlineProjections())
+                                .add(new RemoveRedundantIdentityProjections())
+                                .add(new TransformExistsApplyToCorrelatedJoin(plannerContext))
+                                .build()),
                 new TransformQuantifiedComparisonApplyToCorrelatedJoin(metadata),
                 new IterativeOptimizer(
                         "DecorrelateSubqueries",

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -991,9 +991,6 @@ public class PlanOptimizers
         builder.add(inlineProjections
                 .withName("InlineProjectionsAfterDynamicFilterCleanup"));
         builder.add(new UnaliasSymbolReferences()); // Run unalias after merging projections to simplify projections more efficiently
-        builder.add(columnPruningOptimizer
-                .withName("PruneOutputsAfterFinalUnalias"));
-
         builder.add(new IterativeOptimizer(
                 "PushRemoteExchangeThroughAssignUniqueId",
                 plannerContext,
@@ -1001,6 +998,7 @@ public class PlanOptimizers
                 statsCalculator,
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
+                        .addAll(columnPruningRules)
                         .add(new RemoveRedundantIdentityProjections())
                         .add(new PushRemoteExchangeThroughAssignUniqueId())
                         .add(new InlineProjections())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -499,19 +499,13 @@ public class PlanOptimizers
                         .withName("SimplifyExpressionsBeforeUnalias"),
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
-                        "RemoveIdentityProjections",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
-                new IterativeOptimizer(
                         "MergeSetOperations",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(
+                                new RemoveRedundantIdentityProjections(),
                                 new MergeUnion(),
                                 new MergeIntersect(),
                                 new MergeExcept(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -410,16 +410,6 @@ public class PlanOptimizers
                                 .addAll(new DesugarLambdaExpression().rules())
                                 .build()),
                 new IterativeOptimizer(
-                        "CanonicalizeRowPattern",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.<Rule<?>>builder()
-                                .addAll(new CanonicalizeExpressions(plannerContext).rules())
-                                .add(new OptimizeRowPattern())
-                                .build()),
-                new IterativeOptimizer(
                         "InitialPlanCleanup",
                         plannerContext,
                         ruleStats,
@@ -431,6 +421,7 @@ public class PlanOptimizers
                                 .addAll(simplifyOptimizerRules)
                                 .addAll(new UnwrapRowSubscript(plannerContext).rules())
                                 .addAll(new PushCastIntoRow().rules())
+                                .add(new OptimizeRowPattern())
                                 .addAll(ImmutableSet.of(
                                         new ImplementTableFunctionSource(metadata),
                                         new UnwrapSingleColumnRowInApply(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -825,24 +825,17 @@ public class PlanOptimizers
                 new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(plannerContext, true, false)));
 
         builder.add(new IterativeOptimizer(
-                "PushTopN",
-                plannerContext,
-                ruleStats,
-                statsCalculator,
-                costCalculator,
-                ImmutableSet.of(
-                        new CreatePartialTopN(),
-                        new PushTopNThroughProject(),
-                        new PushTopNThroughOuterJoin(),
-                        new PushTopNThroughUnion(),
-                        new PushTopNIntoTableScan(metadata))));
-        builder.add(new IterativeOptimizer(
-                "ExtractSpatialJoins",
+                "Phase6",
                 plannerContext,
                 ruleStats,
                 statsCalculator,
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
+                        .add(new CreatePartialTopN())
+                        .add(new PushTopNThroughProject())
+                        .add(new PushTopNThroughOuterJoin())
+                        .add(new PushTopNThroughUnion())
+                        .add(new PushTopNIntoTableScan(metadata))
                         .add(new RemoveRedundantIdentityProjections())
                         .addAll(new ExtractSpatialJoins(plannerContext, splitManager, pageSourceManager).rules())
                         .add(new InlineProjections())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -746,7 +746,7 @@ public class PlanOptimizers
                                 new ReplaceJoinOverConstantWithProject(),
                                 new ReplaceWindowWithRowNumber())),
                 new IterativeOptimizer(
-                        "MergeWindows",
+                        "Phase4",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
@@ -754,24 +754,14 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 // add UnaliasSymbolReferences when it's ported
                                 .add(new RemoveRedundantIdentityProjections())
+                                .add(new InlineProjections())
+                                .addAll(columnPruningRules)
                                 .addAll(GatherAndMergeWindows.rules())
                                 .addAll(MergePatternRecognitionNodes.rules())
                                 .add(new PushPredicateThroughProjectIntoRowNumber(plannerContext))
                                 .add(new PushPredicateThroughProjectIntoWindow(plannerContext))
+                                .add(new PushDownProjectionsFromPatternRecognition())
                                 .build()),
-                inlineProjections
-                        .withName("InlineProjectionsAfterWindowMerging"),
-                columnPruningOptimizer // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
-                        .withName("PruneOutputsAfterWindowMerging"),
-                new IterativeOptimizer(
-                        "PushPatternRecognitionProjections",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(
-                                new RemoveRedundantIdentityProjections(),
-                                new PushDownProjectionsFromPatternRecognition())),
                 new MetadataQueryOptimizer(plannerContext),
                 new IterativeOptimizer(
                         "EliminateCrossJoins",

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -791,7 +791,7 @@ public class PlanOptimizers
                 // to leverage predicate pushdown on projected columns.
                 new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(plannerContext, true, false)),
                 new IterativeOptimizer(
-                        "SimplifyAfterProjectionPushdown",
+                        "Phase5",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
@@ -799,16 +799,9 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
                                 .add(new PushPredicateIntoTableScan(plannerContext, false))
+                                .addAll(columnPruningRules)
+                                .add(new RemoveRedundantIdentityProjections())
                                 .build()),
-                columnPruningOptimizer
-                        .withName("PruneOutputsBeforeJoinReordering"),
-                new IterativeOptimizer(
-                        "CleanupBeforeJoinReordering",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 // Because ReorderJoins runs only once,
                 // PredicatePushDown, columnPruningOptimizer and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -699,12 +699,19 @@ public class PlanOptimizers
                                 // It also is run before MultipleDistinctAggregationToMarkDistinct to take precedence f enabled
                                 new ImplementFilteredAggregations(), // DistinctAggregationToGroupBy will add filters if fired
                                 new MultipleDistinctAggregationToMarkDistinct(taskCountEstimator, metadata))), // Run this after aggregation pushdown so that multiple distinct aggregations can be pushed into a connector
-                inlineProjections
-                        .withName("InlineProjectionsAfterDistinctAggregations"),
-                simplifyOptimizer // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
-                        .withName("SimplifyExpressionsAfterDistinctAggregations"),
-                pushProjectionIntoTableScanOptimizer
-                        .withName("PushProjectionIntoTableScanAfterDistinctRewrite"),
+                new IterativeOptimizer(
+                        "Phase3",
+                        plannerContext,
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.<Rule<?>>builder()
+                                .add(new InlineProjections())
+                                .add(new RemoveRedundantIdentityProjections())
+                                .addAll(simplifyOptimizerRules)
+                                .addAll(projectionPushdownRules)
+                                .add(new PushProjectionIntoTableScan(plannerContext, scalarStatsCalculator))
+                                .build()),
                 // Projection pushdown rules may push reducing projections (e.g. dereferences) below filters for potential
                 // pushdown into the connectors. We invoke PredicatePushdown and PushPredicateIntoTableScan after this
                 // to leverage predicate pushdown on projected columns.

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "70",
+                        "999",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "80",
+                        "72",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "86",
+                        "80",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "999",
+                        "62",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "72",
+                        "70",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "90",
+                        "86",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1542,14 +1542,14 @@ public class TestEventListenerBasic
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "82",
+                                "74",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 90., 0., 0.)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "143",
+                                        "131",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1559,7 +1559,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "114",
+                                                "102",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
@@ -1567,7 +1567,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "113",
+                        "101",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1542,14 +1542,14 @@ public class TestEventListenerBasic
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "100",
+                                "82",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 90., 0., 0.)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "173",
+                                        "143",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1559,7 +1559,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "140",
+                                                "114",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
@@ -1567,7 +1567,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "139",
+                        "113",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",


### PR DESCRIPTION
## Summary

`PlanOptimizers` contains ~62 `IterativeOptimizer` instances, many small and back-to-back. This stack consolidates 17 of them by merging adjacent optimizers whose rule sets are disjoint (column pruning, identity-projection removal, simplify, projection pushdown, etc.). The pipeline shape and optimization semantics are unchanged.

The six merged optimizers are named `Phase1`..`Phase6` (by pipeline position) so the names don't carry inferences about their contents — adding or removing a rule shouldn't make the name misleading. Existing non-consolidated optimizers (`InitialPlanCleanup`, `MergeSetOperations`, `PushRemoteExchangeThroughAssignUniqueId`, etc.) keep their original names.

## Stack (10 commits)

```
qpryszxl  Fold ImplementBernoulliSampleAsFilter into pushIntoTableScanOptimizer
voytplrw  Consolidate cleanup-after-set-flattening optimizers          (-> Phase2)
ssmtkukn  Fold CanonicalizeRowPattern into InitialPlanCleanup
kopoklvp  Merge RemoveIdentityProjections into MergeSetOperations
zkyomuzw  Merge window-merging cleanup optimizers                       (-> Phase4)
pwuorrur  Merge final cleanup with PushRemoteExchangeThroughAssignUniqueId
uzszypsz  Merge PushTopN with ExtractSpatialJoins                       (-> Phase6)
ruqskvtk  Merge cleanup optimizers after distinct aggregations          (-> Phase3)
vynkxkqt  Merge limit-pushdown, offset, and simplify before Unalias     (-> Phase1)
nmlsssms  Merge cleanup optimizers before ReorderJoins                  (-> Phase5)
```

## Bisect history

Several consolidations were attempted and dropped after CI bisection:

| Dropped | Why |
|---|---|
| `rzomlnpx` (PostPredicatePushdownCleanup merge) | 10 TPC-H/TPC-DS plan-shape regressions |
| `uqxrprtr` + `rtvpzznt` | Extra `listSchemaNames` call in `TestTrinoDatabaseMetaData` |
| `nowuwwlk`, `posunprr` | Changed dereference pushdown for SemiJoin |
| `wyvkuwos` | Changed identity-projection handling in subquery finalization |

## Test plan

- [x] `core/trino-main` full `Test*` sweep — only pre-existing failures (`TestJsonEncodingUtils` variant-JSON, `TestOAuth2WebUi*` Docker-required) remain
- [x] Per-commit: each commit compiles and passes its affected planner tests
- [x] CI green on both martint/trino#13 (this PR) and trinodb/trino#29503 across `TestLogicalPlanner`, `TestSubqueries`, `TestPredicatePushdown`, `TestUnion`, `TestSetFlattening`, `TestDereferencePushDown`, `TestTpchCostBasedPlan`, `TestPartitionedTpcdsCostBasedPlan`, `TestTrinoDatabaseMetaData`, `TestJsonRepresentation`, `TestEventListenerBasic`, etc.