### PR TITLE
CI test-timing baseline for #18 (no-op)

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -101,6 +101,9 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public abstract class AbstractTestQueryFramework
 {
+    // No-op marker to establish a CI timing baseline: this touches trino-testing so the incremental
+    // builder selects the same impacted-module test matrix as the sql-test-cleanup PR, run against the
+    // unmodified test suites. This branch is for measurement only and is not meant to be merged.
     private static final SqlParser SQL_PARSER = new SqlParser();
 
     private AutoCloseableCloser afterClassCloser;


### PR DESCRIPTION
No-op baseline to measure the test-execution time impact of #18 (Distill the SQL engine test suite).

This branch adds a single comment to `AbstractTestQueryFramework` and nothing else. It touches `trino-testing`, so the incremental builder (GIB) selects the **same impacted-module test matrix** as #18 — but runs the **unmodified** test suites (`AbstractTestQueries` 29 tests, the 8 `BaseConnectorTest` tests, and the full Hive distributed join/window/order-by suites).

Compare this run's job timings against #18 to get the delta. For measurement only — not for merge.